### PR TITLE
Parameterize git branch names.

### DIFF
--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -15,12 +15,15 @@ diego-deployment-staging-bosh-password: PASSWORD
 diego-deployment-staging-bosh-target: 192.168.1.2
 diego-deployment-staging-bosh-username: admin
 diego-manifests-git-url: https://github.com/18f/cg-deploy-diego.git
+diego-manifests-git-branch: master
 diego-private-prod-bucket: SECURE_BUCKET
 diego-private-prod-passphrase: PASSWORD
 diego-private-staging-bucket: SECURE_BUCKET
 diego-private-staging-passphrase: PASSWORD
 diego-release-repo-git-url: https://github.com/cloudfoundry/diego-release.git
+diego-release-repo-git-branch: master
 pipeline-tasks-git-url: https://github.com/18f/cg-pipeline-tasks.git
+pipeline-tasks-git-branch: master
 s3-bosh-releases-access-key-id: AWS_ACCESS_KEY_ID
 s3-bosh-releases-bucket: SECURE_BUCKET
 s3-bosh-releases-secret-access-key: AWS_SECRET_ACCESS_KEY

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -90,7 +90,7 @@ resources:
   type: git
   source:
     uri: {{diego-manifests-git-url}}
-    branch: master
+    branch: {{diego-manifests-git-branch}}
     paths:
     - diego-*.yml
     - generate*
@@ -102,7 +102,7 @@ resources:
   type: git
   source:
     uri: {{diego-release-repo-git-url}}
-    branch: master
+    branch: {{diego-release-repo-git-branch}}
     paths:
     - releases/diego-*.yml
 - name: diego-staging-deployment
@@ -129,7 +129,7 @@ resources:
   type: git
   source:
     uri: {{pipeline-tasks-git-url}}
-    branch: master
+    branch: {{pipeline-tasks-git-url}}
 - name: prodbosh-certificate
   type: s3
   source:


### PR DESCRIPTION
To make it easier to change branches without a PR.
