### PR TITLE
Drop git paths from deploy git source.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -91,9 +91,6 @@ resources:
   source:
     uri: {{diego-manifests-git-url}}
     branch: {{diego-manifests-git-branch}}
-    paths:
-    - diego-*.yml
-    - generate*
 - name: diego-release
   type: bosh-io-release
   source:


### PR DESCRIPTION
The git paths are currently incorrect and don't include the instance count override files. We could add those paths, but I prefer to drop the paths block instead so that we don't have to remember to update paths if file names change later on.
