### PR TITLE
Update example to reflect reality of deployment

### DIFF
--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -182,7 +182,8 @@ sql_overrides:
   bbs:
     db_connection_string: 'postgres://USER:PASS@HOST/diego'
     db_driver: postgres
-    max_open_connections: 500
+    max_idle_connections: 50
+    max_open_connections: 100
     require_ssl: true
     # The following is http://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
     ca_cert: |


### PR DESCRIPTION
This is an update to match what the manifest currently has deployed in production. The RDS instance was choking on all the connections that the old `500` manifest was asking for. This solved some weirdness in the CF API we were experiencing earlier today.

cc: @rememberlenny 