### PR TITLE
Explicitly set container metric reporting interval.

### DIFF
--- a/diego-final.yml
+++ b/diego-final.yml
@@ -29,6 +29,9 @@ jobs:
   <<: *update-template
 
 properties:
+  diego:
+    executor:
+      container_metrics_report_interval: 15s
   cflinuxfs2-rootfs:
     # AWS RDS certificate bundle, including GovCloud intermediate certificate
     # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html


### PR DESCRIPTION
The cloud.gov billing scripts depend on this interval being fixed, so
explicitly set the interval instead of relying on a default that might
change.